### PR TITLE
Fix PLD issue, clean up logging

### DIFF
--- a/src/main/java/com/scaleunlimited/flinkcrawler/functions/BaseAsyncFunction.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/functions/BaseAsyncFunction.java
@@ -39,8 +39,14 @@ public abstract class BaseAsyncFunction<IN, OUT> extends RichAsyncFunction<IN, O
 	
 	@Override
 	public void close() throws Exception {
-		_executor.terminate(_timeoutInSeconds, TimeUnit.SECONDS);
-
+		try {
+			_executor.terminate(_timeoutInSeconds, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			// TODO we have an issue where the TaskManager thread that's
+			// calling us gets interrupted right away, and that in turn
+			// triggers this exception.
+		}
+		
 		super.close();
 	}
 	

--- a/src/main/java/com/scaleunlimited/flinkcrawler/pojos/ValidUrl.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/pojos/ValidUrl.java
@@ -6,13 +6,17 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.scaleunlimited.flinkcrawler.crawldb.IPayload;
 
-import crawlercommons.domains.PaidLevelDomain;
+import crawlercommons.domains.EffectiveTldFinder;
 
 @SuppressWarnings("serial")
 public class ValidUrl extends BaseUrl implements IPayload {
-	
+	private static final Logger LOGGER = LoggerFactory.getLogger(ValidUrl.class);
+
 	private String _protocol;
 	private String _hostname;
 	private String _pld;
@@ -62,7 +66,7 @@ public class ValidUrl extends BaseUrl implements IPayload {
 			_path = url.getPath();
 			_query = url.getQuery();
 
-			_pld = PaidLevelDomain.getPLD(_hostname);
+			_pld = extractPld(_hostname);
 		}
 	}
 	
@@ -210,5 +214,15 @@ public class ValidUrl extends BaseUrl implements IPayload {
 		return true;
 	}
 
+	private static String extractPld(String hostname) {
+        // Use support in EffectiveTldFinder
+        String result = EffectiveTldFinder.getAssignedDomain(hostname, true);
+        if (result == null) {
+        	LOGGER.debug("Hostname {} isn't a valid FQDN", hostname);
+        	return hostname;
+        } else {
+        	return result;
+        }
+    }
 	
 }

--- a/src/main/java/com/scaleunlimited/flinkcrawler/tools/CrawlTopology.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/tools/CrawlTopology.java
@@ -27,6 +27,8 @@ import org.apache.flink.streaming.api.environment.LocalStreamEnvironmentWithAsyn
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.scaleunlimited.flinkcrawler.crawldb.BaseCrawlDB;
 import com.scaleunlimited.flinkcrawler.crawldb.DefaultCrawlDBMerger;
@@ -86,6 +88,7 @@ import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
  * 
  */
 public class CrawlTopology {
+	private static final Logger LOGGER = LoggerFactory.getLogger(CrawlTopology.class);
 
     private StreamExecutionEnvironment _env;
     private String _jobName;
@@ -132,6 +135,12 @@ public class CrawlTopology {
     	
     	LocalStreamEnvironmentWithAsyncExecution env = (LocalStreamEnvironmentWithAsyncExecution)_env;
     	env.stop(_jobID);
+    	
+    	// Wait for 5 seconds for the job to terminate.
+    	long endTime = System.currentTimeMillis() + 5_000L;
+    	while (env.isRunning(_jobID) && (System.currentTimeMillis() < endTime)) {
+    		Thread.sleep(100L);
+    	}
     	
     	// Stop the job execution environment.
     	env.stop();
@@ -588,6 +597,11 @@ public class CrawlTopology {
 	 * @throws Exception
 	 */
 	public void execute(int maxDurationMS, int maxQuietTimeMS) throws Exception {
+		LOGGER.info("Starting async job {}", _jobName);
+		
+		// Reset time, since this is a static that can keep its value from a previous
+		// test run.
+		UrlLogger.resetActivityTime();
 		executeAsync();
 		
 		boolean terminated = false;
@@ -597,6 +611,8 @@ public class CrawlTopology {
 			if (lastActivityTime != UrlLogger.NO_ACTIVITY_TIME) {
 				long curTime = System.currentTimeMillis();
 				if ((curTime - lastActivityTime) > maxQuietTimeMS) {
+					LOGGER.info("Stopping async job {} due to lack of activity", _jobName);
+
 					stop();
 					terminated = true;
 					break;
@@ -607,6 +623,7 @@ public class CrawlTopology {
 		}
 		
 		if (!terminated) {
+			LOGGER.info("Stopping async job {} due to timeout", _jobName);
 			stop();
 			throw new RuntimeException("Job did not terminate in time");
 		}

--- a/src/main/java/com/scaleunlimited/flinkcrawler/utils/ThreadedExecutor.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/utils/ThreadedExecutor.java
@@ -24,6 +24,9 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A wrapper for ThreadPoolExecutor that implements a specific behavior we need.
  * When execute() is called, it succeeds unless all of the threads are busy and the
@@ -31,7 +34,8 @@ import java.util.concurrent.TimeUnit;
  *
  */
 public class ThreadedExecutor {
-    
+	private static final Logger LOGGER = LoggerFactory.getLogger(ThreadedExecutor.class);
+
     /**
      * Always wait for some time when offer() is called. This gives any
      * active threads that much time to complete, before a RejectedExectionException
@@ -108,6 +112,7 @@ public class ThreadedExecutor {
         
         // First just wait for threads to terminate naturally.
         _pool.shutdown();
+        LOGGER.info("Waiting for pool termination ({} {})", duration, timeUnit);
         if (_pool.awaitTermination(duration, timeUnit)) {
             return true;
         }

--- a/src/main/java/com/scaleunlimited/flinkcrawler/utils/UrlLogger.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/utils/UrlLogger.java
@@ -64,6 +64,10 @@ public class UrlLogger {
 		LAST_ACTIVITY_TIME.set(activityTime);
 	}
 
+	public static void resetActivityTime() {
+		LAST_ACTIVITY_TIME.set(NO_ACTIVITY_TIME);
+	}
+	
 	/**
 	 * @return time of last URL activity that was logged.
 	 */

--- a/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedCrawlTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedCrawlTest.java
@@ -108,7 +108,7 @@ public class FocusedCrawlTest {
 		ct.execute(20_000, 5_000);
 		
 		for (Tuple3<Class<?>, String, Map<String, String>> entry : UrlLogger.getLog()) {
-			LOGGER.info(String.format("%s: %s", entry.f0, entry.f1));
+			LOGGER.debug(String.format("%s: %s", entry.f0, entry.f1));
 		}
 		
 		String domain1page1 = normalizer.normalize("domain1.com/page1");

--- a/src/test/java/com/scaleunlimited/flinkcrawler/pojos/ValidUrlTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/pojos/ValidUrlTest.java
@@ -28,6 +28,12 @@ public class ValidUrlTest {
 		
 		url = new ValidUrl("http://wwww.domain.co.jp/path/to/file?query");
 		assertEquals("domain.co.jp", url.getPld());
+		
+		url = new ValidUrl("http://1.2.3.4");
+		assertEquals("1.2.3.4", url.getPld());
+		
+		url = new ValidUrl("http://www.fi.com");
+		assertEquals("fi.com", url.getPld());
 	}
 	
 }

--- a/src/test/java/com/scaleunlimited/flinkcrawler/tools/CrawlTopologyTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/tools/CrawlTopologyTest.java
@@ -119,7 +119,7 @@ public class CrawlTopologyTest {
 		ct.execute(20_000, 5_000);
 		
 		for (Tuple3<Class<?>, String, Map<String, String>> entry : UrlLogger.getLog()) {
-			LOGGER.info(String.format("%s: %s", entry.f0, entry.f1));
+			LOGGER.debug(String.format("%s: %s", entry.f0, entry.f1));
 		}
 		
 		String domain1page1 = normalizer.normalize("domain1.com/page1");

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -48,3 +48,7 @@ log4j.logger.org.apache.http=${my.http.level}
 # probably all be using trace(), not debug() to log their output.
 log4j.logger.com.amazonaws.http=INFO
 
+# Flink (as of 1.3) records an interruption of an async function's collector
+# as if it was an exception (you get a stack trace), even though that's totally OK
+log4j.logger.org.apache.flink.streaming.api.operators.async.Emitter=INFO
+


### PR DESCRIPTION
- When closing an async function, we’re getting interrupted right away,
which causes the stream termination to fail. For now, catch the
InterruptedException

- Use EffectiveTldFinder in crawler-commons vs. PaidLevelDomain

- Wait for a job we’re stopping to actually stop, before terminating
the FlinkMiniCluster

- Add some extra logging during threaded executor termination

- Clear out UrlLogger last activity at the start of each test, so that
we don’t have the focused crawl test failing since it follows the
regular crawl test.

- Hide bogus Flink stack trace while shutting down async functions.