### PR TITLE
Support integration tests #59

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -722,9 +722,9 @@ under the License.
 	            <executions>
 	                <execution>
 	                    <id>add-test-source</id>
-	                    <phase>generate-test-sources</phase>
+	                    <phase>generate-sources</phase>
 	                    <goals>
-	                        <goal>add-test-source</goal>
+	                        <goal>add-source</goal>
 	                    </goals>
 	                    <configuration>
 	                        <sources>


### PR DESCRIPTION
If the phase for the build-helper-maven-plugin is set to generate-test-sources, and the goal is set to add-test-source, the files are added under the src/test/java package.
So instead add the src/it/java files as a separate “regular” source directory - so that they show up correctly in Eclipse.