### PR TITLE
Added new abstract methods (for open and close) to BasePageParser and…

### DIFF
--- a/src/main/java/com/scaleunlimited/flinkcrawler/focused/BasePageScorer.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/focused/BasePageScorer.java
@@ -2,6 +2,7 @@ package com.scaleunlimited.flinkcrawler.focused;
 
 import java.io.Serializable;
 
+import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
 
 @SuppressWarnings("serial")
@@ -10,6 +11,9 @@ public abstract class BasePageScorer implements Serializable {
 	public BasePageScorer() {
 	}
 
-	public abstract float score(ParserResult parse);
+    public abstract void open(CrawlerAccumulator crawlerAccumulator) throws Exception;
+    public abstract void close() throws Exception;
+
+    public abstract float score(ParserResult parse);
 
 }

--- a/src/main/java/com/scaleunlimited/flinkcrawler/focused/FocusedPageParser.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/focused/FocusedPageParser.java
@@ -1,5 +1,6 @@
 package com.scaleunlimited.flinkcrawler.focused;
 
+import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
 import com.scaleunlimited.flinkcrawler.parser.SimplePageParser;
 import com.scaleunlimited.flinkcrawler.pojos.ExtractedUrl;
@@ -15,6 +16,19 @@ public class FocusedPageParser extends SimplePageParser {
 		
 		_pageScorer = pageScorer;
 	}
+	
+	@Override
+	public void open(CrawlerAccumulator crawlerAccumulator) throws Exception {
+		super.open(crawlerAccumulator);
+		_pageScorer.open(crawlerAccumulator);
+	}
+	
+	@Override
+	public void close() throws Exception {
+		_pageScorer.close();
+		super.close();
+	}
+	
 	
 	@Override
 	public ParserResult parse(FetchedUrl fetchedUrl) throws Exception {

--- a/src/main/java/com/scaleunlimited/flinkcrawler/functions/ParseFunction.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/functions/ParseFunction.java
@@ -1,10 +1,13 @@
 package com.scaleunlimited.flinkcrawler.functions;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.parser.BasePageParser;
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
 import com.scaleunlimited.flinkcrawler.pojos.ExtractedUrl;
@@ -22,6 +25,13 @@ public class ParseFunction extends BaseFlatMapFunction<FetchedUrl, Tuple3<Extrac
         _parser = parser;
     }
 
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		RuntimeContext context = getRuntimeContext();
+		_parser.open( new CrawlerAccumulator(context));
+	}
+	
 	@Override
 	public void flatMap(FetchedUrl fetchedUrl, Collector<Tuple3<ExtractedUrl, ParsedUrl, String>> collector) throws Exception {
 		record(this.getClass(), fetchedUrl);

--- a/src/main/java/com/scaleunlimited/flinkcrawler/functions/ParseFunction.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/functions/ParseFunction.java
@@ -29,7 +29,7 @@ public class ParseFunction extends BaseFlatMapFunction<FetchedUrl, Tuple3<Extrac
 	public void open(Configuration parameters) throws Exception {
 		super.open(parameters);
 		RuntimeContext context = getRuntimeContext();
-		_parser.open( new CrawlerAccumulator(context));
+		_parser.open(new CrawlerAccumulator(context));
 	}
 	
 	@Override

--- a/src/main/java/com/scaleunlimited/flinkcrawler/functions/ParseFunction.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/functions/ParseFunction.java
@@ -46,10 +46,12 @@ public class ParseFunction extends BaseFlatMapFunction<FetchedUrl, Tuple3<Extrac
 			return;
 		}
 		
-		// Output the content
-		collector.collect(new Tuple3<ExtractedUrl, ParsedUrl, String>(null, result.getParsedUrl(), null));
+		// Output the content only if we have a score that is greater than 0
+		if (result.getParsedUrl().getScore() > 0) {
+			collector.collect(new Tuple3<ExtractedUrl, ParsedUrl, String>(null, result.getParsedUrl(), null));
+		}
 		
-		// Output the links
+		// However, output all the links (irrespective of score) - we'll ignore fetching the 0 score ones
 		for (ExtractedUrl outlink : result.getExtractedUrls()) {
 			String message =
 				String.format(	"Extracted '%s' from '%s'",

--- a/src/main/java/com/scaleunlimited/flinkcrawler/metrics/CrawlerAccumulator.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/metrics/CrawlerAccumulator.java
@@ -1,0 +1,26 @@
+package com.scaleunlimited.flinkcrawler.metrics;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+
+public class CrawlerAccumulator {
+
+	private RuntimeContext _runtimeContext;
+
+	public CrawlerAccumulator(RuntimeContext runtimeContext) {
+		_runtimeContext = runtimeContext;
+	}
+	
+	public void increment(Enum<?> e) {
+		CounterUtils.increment(_runtimeContext, e);
+	}
+	
+
+	public void increment(Enum<?> e, long l) {
+		CounterUtils.increment(_runtimeContext, e, l);
+	}
+	
+	public void increment(String group, String counter, long l) {
+		CounterUtils.increment(_runtimeContext, group, counter, l);
+	}
+
+}

--- a/src/main/java/com/scaleunlimited/flinkcrawler/metrics/CrawlerAccumulator.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/metrics/CrawlerAccumulator.java
@@ -10,17 +10,33 @@ public class CrawlerAccumulator {
 		_runtimeContext = runtimeContext;
 	}
 	
+	/**
+	 * Increment the counter for the enum e by 1
+	 * @param e The enum to use as a name
+	 */
 	public void increment(Enum<?> e) {
 		CounterUtils.increment(_runtimeContext, e);
 	}
 	
-
-	public void increment(Enum<?> e, long l) {
-		CounterUtils.increment(_runtimeContext, e, l);
+	/**
+	 * Modify the counter for the enum e by changeBy - if positive the counter is 
+	 * incremented; if negative it is decremented.
+	 * @param e The enum to use as a name
+	 * @param changeBy the value to modify the counter by
+	 */
+	public void increment(Enum<?> e, long changeBy) {
+		CounterUtils.increment(_runtimeContext, e, changeBy);
 	}
 	
-	public void increment(String group, String counter, long l) {
-		CounterUtils.increment(_runtimeContext, group, counter, l);
+	/**
+	 * Modify the counter by changeBy - if positive the counter is 
+	 * incremented; if negative it is decremented.
+	 * @param group The name of the group the counter belongs to
+	 * @param counter The name of the counter
+	 * @param changeBy the value to modify the counter by
+	 */
+	public void increment(String group, String counter, long changeBy) {
+		CounterUtils.increment(_runtimeContext, group, counter, changeBy);
 	}
 
 }

--- a/src/main/java/com/scaleunlimited/flinkcrawler/parser/BasePageParser.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/parser/BasePageParser.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.apache.tika.utils.CharsetUtils;
 
 import com.scaleunlimited.flinkcrawler.config.ParserPolicy;
+import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.pojos.FetchedUrl;
 import com.scaleunlimited.flinkcrawler.utils.HttpUtils;
 
@@ -17,6 +18,7 @@ import crawlercommons.util.Headers;
 public abstract class BasePageParser implements Serializable {
 
     private ParserPolicy _policy;
+	private transient CrawlerAccumulator _crawlerAccumulator;
     
     public BasePageParser(ParserPolicy policy) {
         _policy = policy;
@@ -26,8 +28,20 @@ public abstract class BasePageParser implements Serializable {
         return _policy;
     }
 
+    public abstract void open(CrawlerAccumulator crawlerAccumulator) throws Exception;
+    public abstract void close() throws Exception;
+    
     public abstract ParserResult parse(FetchedUrl fetchedUrl) throws Exception;
 
+    public void setAccumulator(CrawlerAccumulator crawlerAccumulator) {
+    	_crawlerAccumulator = crawlerAccumulator;
+    }
+ 
+    public CrawlerAccumulator getAccumulator() {
+    	return _crawlerAccumulator;
+    }
+
+    
     /**
      * Extract encoding from content-type
      * 

--- a/src/main/java/com/scaleunlimited/flinkcrawler/parser/SimplePageParser.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/parser/SimplePageParser.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.scaleunlimited.flinkcrawler.config.ParserPolicy;
+import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.pojos.FetchedUrl;
 import com.scaleunlimited.flinkcrawler.utils.IoUtils;
 
@@ -109,7 +110,16 @@ public class SimplePageParser extends BasePageParser {
         _parseContext = parseContext;
     }
 
-    protected synchronized void init() {
+    @Override
+	public void open(CrawlerAccumulator crawlerAccumulator) throws Exception {
+		setAccumulator(crawlerAccumulator);
+	}
+
+	@Override
+	public void close() throws Exception {
+	}
+
+	protected synchronized void init() {
         if (_parser == null) {
             _parser = new AutoDetectParser();
         }

--- a/src/main/java/com/scaleunlimited/flinkcrawler/parser/SimpleSiteMapParser.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/parser/SimpleSiteMapParser.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.scaleunlimited.flinkcrawler.config.ParserPolicy;
+import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.pojos.ExtractedUrl;
 import com.scaleunlimited.flinkcrawler.pojos.FetchedUrl;
 
@@ -29,6 +30,15 @@ public class SimpleSiteMapParser extends BasePageParser {
 
     public SimpleSiteMapParser(ParserPolicy policy) {
 		super(policy);
+	}
+
+	@Override
+	public void open(CrawlerAccumulator crawlerAccumulator) throws Exception {
+		setAccumulator(crawlerAccumulator);
+	}
+
+	@Override
+	public void close() throws Exception {
 	}
 
 	private void init() {

--- a/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedCrawlTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedCrawlTest.java
@@ -17,6 +17,7 @@ import com.scaleunlimited.flinkcrawler.fetcher.MockRobotsFetcher;
 import com.scaleunlimited.flinkcrawler.fetcher.SiteMapGraphFetcher;
 import com.scaleunlimited.flinkcrawler.fetcher.WebGraphFetcher;
 import com.scaleunlimited.flinkcrawler.functions.FetchUrlsFunction;
+import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
 import com.scaleunlimited.flinkcrawler.parser.SimpleSiteMapParser;
 import com.scaleunlimited.flinkcrawler.pojos.ParsedUrl;
@@ -136,6 +137,14 @@ public class FocusedCrawlTest {
 		public float score(ParserResult parse) {
 			String title = parse.getParsedUrl().getTitle();
 			return Float.parseFloat(title.substring("Synthetic page - score = ".length()));
+		}
+
+		@Override
+		public void open(CrawlerAccumulator crawlerAccumulator) throws Exception {
+		}
+
+		@Override
+		public void close() throws Exception {
 		}
 	}
 

--- a/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedPageParserTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedPageParserTest.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
+import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
 import com.scaleunlimited.flinkcrawler.pojos.FetchedUrl;
 import com.scaleunlimited.flinkcrawler.pojos.ValidUrl;
@@ -18,7 +19,7 @@ public class FocusedPageParserTest {
 	public void test() throws Exception {
 		TestPageScorer pageScorer = new TestPageScorer();
 		FocusedPageParser parser = new FocusedPageParser(pageScorer);
-		
+		parser.open(null);
 		ValidUrl url = new ValidUrl("http://domain.com/page.html");
 		Headers headers = new Headers();
 		byte[] content = "<html><head><title></title></head><body><p>0.75</p></body></html>".getBytes(StandardCharsets.UTF_8);
@@ -33,6 +34,14 @@ public class FocusedPageParserTest {
 		@Override
 		public float score(ParserResult parse) {
 			return Float.parseFloat(parse.getParsedUrl().getParsedText());
+		}
+
+		@Override
+		public void open(CrawlerAccumulator crawlerAccumulator) throws Exception {
+		}
+
+		@Override
+		public void close() throws Exception {
 		}
 	}
 

--- a/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedPageParserTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedPageParserTest.java
@@ -1,10 +1,15 @@
 package com.scaleunlimited.flinkcrawler.focused;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
@@ -19,7 +24,13 @@ public class FocusedPageParserTest {
 	public void test() throws Exception {
 		TestPageScorer pageScorer = new TestPageScorer();
 		FocusedPageParser parser = new FocusedPageParser(pageScorer);
-		parser.open(null);
+		
+		CrawlerAccumulator mockCrawlerAccumulator = Mockito.mock(CrawlerAccumulator.class);
+		doNothing().when(mockCrawlerAccumulator).increment(any(Enum.class));
+		doNothing().when(mockCrawlerAccumulator).increment(any(Enum.class), anyLong());
+		doNothing().when(mockCrawlerAccumulator).increment(anyString(), anyString(), anyLong());
+		
+		parser.open(mockCrawlerAccumulator);
 		ValidUrl url = new ValidUrl("http://domain.com/page.html");
 		Headers headers = new Headers();
 		byte[] content = "<html><head><title></title></head><body><p>0.75</p></body></html>".getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
… BasePageScorer.

Added a new class “CrawlerAccumulator” that is passed in with the open() call in BasePageParser and BasePageScorer.

I had to keep the init() method separate (instead of calling it in the open) as I was running into test failures - which I don't fully understand. So, feedback around that would be useful.