### PR TITLE
Name the stream returned after assigning the sink to parsedUrls - thi…

### DIFF
--- a/src/main/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopologyBuilder.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopologyBuilder.java
@@ -405,9 +405,10 @@ public class CrawlTopologyBuilder {
         crawlDbIteration.closeWith(robotBlockedUrls.union(queuedStatusUrls, fetchStatusUrls, newUrls));
 
         // Save off parsed page content by passing it on to the provided content sink function.
-        parsedUrls
-            .name("Select fetched content")
-            .addSink(_contentSink)
+        DataStreamSink<ParsedUrl> content = parsedUrls
+            .addSink(_contentSink);
+
+        content = content
             .name("ContentSink")
             .setParallelism(parseParallelism);
 
@@ -425,7 +426,6 @@ public class CrawlTopologyBuilder {
                     
                 })
                 .name("Select fetched content text")
-                .name("ContentTextSink")
                 .setParallelism(parseParallelism);
 
         DataStreamSink<String> contentTextSink;
@@ -438,7 +438,7 @@ public class CrawlTopologyBuilder {
         }
         
         contentTextSink.name("ContentTextSink")
-        .setParallelism(parseParallelism);
+            .setParallelism(parseParallelism);
 
         return new CrawlTopology(_env, _jobName);
     }

--- a/src/main/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopologyBuilder.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopologyBuilder.java
@@ -405,15 +405,13 @@ public class CrawlTopologyBuilder {
         crawlDbIteration.closeWith(robotBlockedUrls.union(queuedStatusUrls, fetchStatusUrls, newUrls));
 
         // Save off parsed page content by passing it on to the provided content sink function.
-        DataStreamSink<ParsedUrl> content = parsedUrls
-            .addSink(_contentSink);
-
-        content = content
+       parsedUrls
+            .addSink(_contentSink)
             .name("ContentSink")
             .setParallelism(parseParallelism);
 
-        // Save off parsed page content text. So just extract the parsed content text piece of the Tuple3, and
-        // then pass it on to the provided content sink function (or just send it to the console).
+        // Save off parsed page content text. But first replace all tabs and returns with a space, since we 
+        // are outputting one record per line.
         DataStream<String> contentText = parsedUrls
                 .map(new MapFunction<ParsedUrl, String>() {
         


### PR DESCRIPTION
…s results in the ParseFunction getting correctly labelled in the execution graph (with two sinks; the first one for content, and the second for the content-text) #131