### PR TITLE
Cleaner termination

### DIFF
--- a/src/it/java/com/scaleunlimited/flinkcrawler/fetcher/commoncrawl/CommonCrawlFetcherIT.java
+++ b/src/it/java/com/scaleunlimited/flinkcrawler/fetcher/commoncrawl/CommonCrawlFetcherIT.java
@@ -64,10 +64,8 @@ public class CommonCrawlFetcherIT {
     public void testSpecificUrl() throws Exception {
         BaseHttpFetcher fetcher = makeFetcher(1);
 
-        FetchedResult result = fetcher.get("http://www.domain.com/");
+        FetchedResult result = fetcher.get("https://customer.xfinity.com/");
         assertEquals(200, result.getStatusCode());
-        assertEquals("http://www.domain.com//", result.getBaseUrl());
-        assertEquals("http://www.domain.com/", result.getFetchedUrl());
     }
 
     @Test

--- a/src/main/java/com/scaleunlimited/flinkcrawler/config/CrawlTerminator.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/config/CrawlTerminator.java
@@ -1,0 +1,9 @@
+package com.scaleunlimited.flinkcrawler.config;
+
+import java.io.Serializable;
+
+@SuppressWarnings("serial")
+public abstract class CrawlTerminator implements Serializable {
+
+    public abstract boolean isTerminated();
+}

--- a/src/main/java/com/scaleunlimited/flinkcrawler/config/CrawlTerminator.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/config/CrawlTerminator.java
@@ -5,5 +5,9 @@ import java.io.Serializable;
 @SuppressWarnings("serial")
 public abstract class CrawlTerminator implements Serializable {
 
+    public void open() {
+        
+    }
+    
     public abstract boolean isTerminated();
 }

--- a/src/main/java/com/scaleunlimited/flinkcrawler/pojos/BaseUrl.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/pojos/BaseUrl.java
@@ -8,8 +8,8 @@ import com.scaleunlimited.flinkcrawler.utils.FlinkUtils;
 @SuppressWarnings("serial")
 public abstract class BaseUrl implements Serializable {
 
-    private static String TICKLER_URL_FORMAT = "http://flickcrawler-tickler-url-%d.com";
-    private static String TERMINATE_URL_FORMAT = "http://flickcrawler-terminate-url-%d.com";
+    private static String TICKLER_URL_FORMAT = "flickcrawler-tickler-url-%d.com";
+    private static String TERMINATE_URL_FORMAT = "flickcrawler-terminate-url-%d.com";
 
     private String _url;
     private UrlType _urlType;
@@ -95,13 +95,13 @@ public abstract class BaseUrl implements Serializable {
     }
 
     public static BaseUrl makeTicklerUrl(int maxParallelism, int parallelism, int operatorIndex) {
-        return new BaseUrl(FlinkUtils.makeKeyForOperatorIndex(TICKLER_URL_FORMAT, maxParallelism,
+        return new BaseUrl("http://" + FlinkUtils.makeKeyForOperatorIndex(TICKLER_URL_FORMAT, maxParallelism,
                 parallelism, operatorIndex), UrlType.TICKLER) {
         };
     }
 
     public static BaseUrl makeTerminateUrl(int maxParallelism, int parallelism, int operatorIndex) {
-        return new BaseUrl(FlinkUtils.makeKeyForOperatorIndex(TERMINATE_URL_FORMAT, maxParallelism,
+        return new BaseUrl("http://" + FlinkUtils.makeKeyForOperatorIndex(TERMINATE_URL_FORMAT, maxParallelism,
                 parallelism, operatorIndex), UrlType.TERMINATION) {
         };
     }

--- a/src/main/java/com/scaleunlimited/flinkcrawler/pojos/CrawlStateUrl.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/pojos/CrawlStateUrl.java
@@ -47,7 +47,7 @@ public class CrawlStateUrl extends ValidUrl {
     }
 
     public void setStatus(FetchStatus status) {
-        if (status != _previousStatus) {
+        if (status != _status) {
             _previousStatus = _status;
             _status = status;
         }
@@ -55,8 +55,9 @@ public class CrawlStateUrl extends ValidUrl {
     
     public void restorePreviousStatus() {
         if (_previousStatus == null) {
-            throw new RuntimeException(this + "Has no saved previous status!");
+            throw new IllegalStateException("No previous status for " + toString());
         }
+        
         _status = _previousStatus;
         _previousStatus = null;
     }
@@ -97,6 +98,7 @@ public class CrawlStateUrl extends ValidUrl {
         _score = url._score;
         _status = url._status;
         _statusTime = url._statusTime;
+        _previousStatus = url._previousStatus;
     }
 
     @Override
@@ -104,6 +106,8 @@ public class CrawlStateUrl extends ValidUrl {
         // TODO add more fields to the response.
         if (getUrlType() == UrlType.REGULAR) {
             return String.format("%s (%s at %d)", getUrl(), _status, _statusTime);
+        } else if (getUrlType() == UrlType.DOMAIN) {
+            return String.format("%s (%s)", getUrl(), getUrlType());
         } else {
             return String.format("%s", getUrlType());
         }
@@ -114,6 +118,7 @@ public class CrawlStateUrl extends ValidUrl {
         final int prime = 31;
         int result = super.hashCode();
         result = prime * result + (int) (_nextFetchTime ^ (_nextFetchTime >>> 32));
+        result = prime * result + ((_previousStatus == null) ? 0 : _previousStatus.hashCode());
         result = prime * result + Float.floatToIntBits(_score);
         result = prime * result + ((_status == null) ? 0 : _status.hashCode());
         result = prime * result + (int) (_statusTime ^ (_statusTime >>> 32));
@@ -130,6 +135,8 @@ public class CrawlStateUrl extends ValidUrl {
             return false;
         CrawlStateUrl other = (CrawlStateUrl) obj;
         if (_nextFetchTime != other._nextFetchTime)
+            return false;
+        if (_previousStatus != other._previousStatus)
             return false;
         if (Float.floatToIntBits(_score) != Float.floatToIntBits(other._score))
             return false;

--- a/src/main/java/com/scaleunlimited/flinkcrawler/tools/CrawlTool.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/tools/CrawlTool.java
@@ -110,8 +110,7 @@ public class CrawlTool {
 
         CrawlTopologyBuilder builder = new CrawlTopologyBuilder(env).setUserAgent(userAgent)
                 .setUrlLengthener(urlLengthener)
-                .setUrlSource(new SeedUrlSource(options.getCrawlDbParallelism(),
-                        options.getSeedUrlsFilename(), RawUrl.DEFAULT_SCORE))
+                .setUrlSource(new SeedUrlSource(options.getSeedUrlsFilename(), RawUrl.DEFAULT_SCORE))
                 .setRobotsFetcherBuilder(robotsFetcherBuilder).setUrlFilter(urlValidator)
                 .setSiteMapFetcherBuilder(siteMapFetcherBuilder)
                 .setPageFetcherBuilder(pageFetcherBuilder)

--- a/src/main/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopology.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopology.java
@@ -2,7 +2,6 @@ package com.scaleunlimited.flinkcrawler.topology;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -13,7 +12,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.scaleunlimited.flinkcrawler.pojos.RawUrl;
 import com.scaleunlimited.flinkcrawler.utils.FlinkUtils;
 import com.scaleunlimited.flinkcrawler.utils.UrlLogger;
 
@@ -102,7 +100,7 @@ public class CrawlTopology {
      *            Length of time w/no recorded activity after which we'll terminate.
      * @throws Exception
      */
-    public void execute(int maxDurationMS, int maxQuietTimeMS) throws Exception {
+    public void execute(long maxDurationMS, long maxQuietTimeMS) throws Exception {
         LOGGER.info("Starting async job {}", _jobName);
 
         // Reset time, since this is a static that can keep its value from a previous

--- a/src/main/java/com/scaleunlimited/flinkcrawler/utils/FetchQueue.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/utils/FetchQueue.java
@@ -55,20 +55,26 @@ public class FetchQueue implements Serializable {
             // TODO refetch URL if fetch time is earlier than "now".
             return url;
         } else if (_fetchQueue.size() < _maxQueueSize) {
-            _fetchQueue.add(url);
-            sortQueue();
+            addToQueue(url);
             
             return null;
         } else if (url.getScore() <= _fetchQueue.getLast().getScore()) {
             return url;
         } else {
-            _fetchQueue.add(url);
-            sortQueue();
+            addToQueue(url);
+
             return _fetchQueue.removeLast();
         }
     }
 
-    private void sortQueue() {
+    private void addToQueue(CrawlStateUrl url) {
+        // We need to make a copy of this, so that if/when we change it,
+        // we're not also accidentally changing our state value.
+        CrawlStateUrl urlToQueue = new CrawlStateUrl();
+        urlToQueue.setFrom(url);
+        urlToQueue.setStatus(FetchStatus.QUEUED);
+        _fetchQueue.add(urlToQueue);
+        
         _fetchQueue.sort(new Comparator<CrawlStateUrl>() {
 
             @Override

--- a/src/test/java/com/scaleunlimited/flinkcrawler/pojos/CrawlStateUrlTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/pojos/CrawlStateUrlTest.java
@@ -18,5 +18,35 @@ public class CrawlStateUrlTest {
 
         assertThat(newUrl).isEqualTo(csu);
     }
+    
+    @Test
+    public void testSetFrom() throws Exception {
+        ValidUrl url = new ValidUrl("http://domain.com?q=s");
+        CrawlStateUrl csu1 = new CrawlStateUrl(url, FetchStatus.UNFETCHED, 100);
+        csu1.setStatus(FetchStatus.FETCHING);
+        
+        CrawlStateUrl csu2 = new CrawlStateUrl();
+        csu2.setFrom(csu1);
+        assertThat(csu2).isEqualToComparingFieldByField(csu1);
+    }
+    
+    @Test
+    public void testPreviousStatus() throws Exception {
+        ValidUrl url = new ValidUrl("http://domain.com?q=s");
+        CrawlStateUrl csu = new CrawlStateUrl(url, FetchStatus.FETCHING, 100);
+        csu.setScore(1.0f);
+        csu.setNextFetchTime(1000L);
+
+        csu.setStatus(FetchStatus.FETCHED);
+        assertThat(csu.getStatus()).isEqualTo(FetchStatus.FETCHED);
+        csu.restorePreviousStatus();
+        assertThat(csu.getStatus()).isEqualTo(FetchStatus.FETCHING);
+
+        // If we switch from and then back to a status, make sure it
+        // actually does the switch.
+        csu.setStatus(FetchStatus.FETCHED);
+        csu.setStatus(FetchStatus.FETCHING);
+        assertThat(csu.getStatus()).isEqualTo(FetchStatus.FETCHING);
+    }
 
 }

--- a/src/test/java/com/scaleunlimited/flinkcrawler/pojos/RawUrlTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/pojos/RawUrlTest.java
@@ -8,8 +8,13 @@ public class RawUrlTest {
 
     @Test
     public void testTicklerGeneration() {
-        RawUrl url = RawUrl.makeRawTickerUrl(128, 2, 0);
-        assertFalse(url.isRegular());
+        final int maxParallelism = 128;
+        final int parallelism = 3;
+        
+        for (int operatorIndex = 0; operatorIndex < parallelism; operatorIndex++) {
+            RawUrl url = RawUrl.makeRawTickerUrl(maxParallelism, parallelism, operatorIndex);
+            System.out.format("%d: %s\n", operatorIndex, url.getUrl());
+            assertFalse(url.isRegular());
+        }
     }
-
 }

--- a/src/test/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopologyTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopologyTest.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.scaleunlimited.flinkcrawler.config.CrawlTerminator;
 import com.scaleunlimited.flinkcrawler.fetcher.MockRobotsFetcher;
 import com.scaleunlimited.flinkcrawler.fetcher.MockUrlLengthenerFetcher;
 import com.scaleunlimited.flinkcrawler.fetcher.SiteMapGraphFetcher;
@@ -93,15 +92,18 @@ public class CrawlTopologyTest {
             FileUtils.deleteFileOrDirectory(contentTextFile);
         }
 
-        final int crawlDbParallelism = 3;
-        final long maxQuietTime = 5_000L;
-        
-        SeedUrlSource seedUrlSource = new SeedUrlSource(crawlDbParallelism, 1.0f, "http://domain1.com");
+        final long maxQuietTime = 2_000L;
+        SeedUrlSource seedUrlSource = new SeedUrlSource(1.0f, "http://domain1.com");
         seedUrlSource.setTerminator(new NoActivityCrawlTerminator(maxQuietTime));
         
         CrawlTopologyBuilder builder = new CrawlTopologyBuilder(env)
                 // Explicitly set parallelism so that it doesn't vary based on # of cores
-                .setParallelism(2)
+                .setParallelism(3)
+                
+                // Set a timeout that is safe during our test, given max latency with checkpointing
+                // during a run.
+                .setIterationTimeout(2000L)
+                
                 .setUrlSource(seedUrlSource)
                 .setUrlLengthener(new SimpleUrlLengthener(
                         new MockUrlLengthenerFetcher.MockUrlLengthenerFetcherBuilder(
@@ -113,6 +115,7 @@ public class CrawlTopologyTest {
                 .setContentSink(new DiscardingSink<ParsedUrl>())
                 .setContentTextFile(contentTextFile.getAbsolutePath()).setUrlNormalizer(normalizer)
                 .setUrlFilter(new SimpleUrlValidator())
+                
                 // Create MockSitemapFetcher - that will return a valid sitemap
                 .setSiteMapFetcherBuilder(new SiteMapGraphFetcher.SiteMapGraphFetcherBuilder(
                         new SiteMapGraphFetcher(sitemapGraph)))
@@ -125,10 +128,9 @@ public class CrawlTopologyTest {
         File dotFile = new File(testDir, "topology.dot");
         ct.printDotFile(dotFile);
 
-        // Execute for a maximum of 20 seconds, but terminate (successfully)
-        // if there's no activity for the max time.
-        ct.execute(20_000L, maxQuietTime);
-        // ct.execute(200_000, 200_000);
+        // Execute for a maximum of 20 seconds.
+        ct.execute(20_000L);
+        // ct.execute(200_000);
 
         for (Tuple3<Class<?>, String, Map<String, String>> entry : UrlLogger.getLog()) {
             LOGGER.debug("{}: {}", entry.f0, entry.f1);
@@ -194,29 +196,4 @@ public class CrawlTopologyTest {
         ;
     }
     
-    @SuppressWarnings("serial")
-    private static class NoActivityCrawlTerminator extends CrawlTerminator {
-
-        private long _maxQuietTimeMS;
-        
-        public NoActivityCrawlTerminator(long maxQuietTimeMS) {
-            _maxQuietTimeMS = maxQuietTimeMS;
-        }
-        
-        @Override
-        public boolean isTerminated() {
-            long lastActivityTime = UrlLogger.getLastActivityTime();
-            if (lastActivityTime != UrlLogger.NO_ACTIVITY_TIME) {
-                long curTime = System.currentTimeMillis();
-                if ((curTime - lastActivityTime) > _maxQuietTimeMS) {
-                    LOGGER.info("Terminating seed URL source to lack of activity");
-                    return false;
-                }
-            }
-            
-            return false;
-        }
-        
-    }
-
 }

--- a/src/test/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopologyTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopologyTest.java
@@ -127,7 +127,7 @@ public class CrawlTopologyTest {
 
         // Execute for a maximum of 20 seconds, but terminate (successfully)
         // if there's no activity for the max time.
-        ct.execute(20_000L, maxQuietTime * 2);
+        ct.execute(20_000L, maxQuietTime);
         // ct.execute(200_000, 200_000);
 
         for (Tuple3<Class<?>, String, Map<String, String>> entry : UrlLogger.getLog()) {

--- a/src/test/java/com/scaleunlimited/flinkcrawler/topology/NoActivityCrawlTerminator.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/topology/NoActivityCrawlTerminator.java
@@ -1,0 +1,41 @@
+package com.scaleunlimited.flinkcrawler.topology;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.scaleunlimited.flinkcrawler.config.CrawlTerminator;
+import com.scaleunlimited.flinkcrawler.utils.UrlLogger;
+
+@SuppressWarnings("serial")
+public class NoActivityCrawlTerminator extends CrawlTerminator {
+    static final Logger LOGGER = LoggerFactory.getLogger(NoActivityCrawlTerminator.class);
+
+    private long _maxQuietTimeMS;
+    
+    public NoActivityCrawlTerminator(long maxQuietTimeMS) {
+        _maxQuietTimeMS = maxQuietTimeMS;
+    }
+    
+    @Override
+    public void open() {
+        super.open();
+        
+        UrlLogger.resetActivityTime();
+    }
+    
+    @Override
+    public boolean isTerminated() {
+        long lastActivityTime = UrlLogger.getLastActivityTime();
+        if (lastActivityTime != UrlLogger.NO_ACTIVITY_TIME) {
+            long curTime = System.currentTimeMillis();
+            if ((curTime - lastActivityTime) > _maxQuietTimeMS) {
+                LOGGER.info("Terminating seed URL source due to lack of activity");
+                return true;
+            }
+        }
+        
+        return false;
+    }
+    
+}
+

--- a/src/test/java/com/scaleunlimited/flinkcrawler/utils/FetchQueueTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/utils/FetchQueueTest.java
@@ -35,13 +35,13 @@ public class FetchQueueTest {
 
         CrawlStateUrl url3 = new CrawlStateUrl(new RawUrl("http://domain.com/page3"));
         url3.setScore(0.5f);
-        assertEquals(url3, queue.add(url3));
+        assertTrue(url3 == queue.add(url3));
         
         // Add a higher-scoring URL. We should get back the lowest-scoring URL in the
         // fetch queue.
         CrawlStateUrl url4 = new CrawlStateUrl(new RawUrl("http://domain.com/page4"));
         url4.setScore(2.0f);
-        assertEquals(url1, queue.add(url4));
+        assertSameUrl(url1, queue.add(url4));
 
         // Verify we get URLs from the queue in priority order.
         assertSameUrl(url4, queue.poll());

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -53,6 +53,10 @@ log4j.logger.org.apache.flink.api.java.ClosureCleaner=INFO
 # as if it was an exception (you get a stack trace), even though that's totally OK
 log4j.logger.org.apache.flink.streaming.api.operators.async.Emitter=INFO
 
+# Flink (as of 1.4) records the absence of queriable state support as if it
+# were an exception, even though that's optional.
+log4j.logger.org.apache.flink.runtime.query.QueryableStateUtils=INFO
+
 # SiteMapParser records exclusion of URLs (because they aren't under the same domain
 # as the sitemap) at WARN, though should be DEBUG. So set level to ERROR to exclude.
 log4j.logger.crawlercommons.sitemaps.SiteMapParser=ERROR

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -23,17 +23,13 @@ my.console.pattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}:%L - %m%n
 my.http.level=INFO
 my.log.dir=./logs
 
-
 # Define the root logger to the system property "my.root.logger".
 log4j.rootLogger=${my.root.logger}
 
 # Logging Threshold
 log4j.threshhold=ALL
 
-#
 # console
-# Add "console" to my.root.logger above if you want to use this 
-#
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
Now terminate tickler URLs, and use a short iteration timeout to trigger a clean termination. To make this work properly, the DomainDBFunction has to constantly be sending URLs back through the iterator, otherwise it will shut down prematurely (it needs to be tickled regularly to keep it alive).

Also fixed up issue with tickler key generation being based on `http://<key>`, but partitioning happens with just the `<key>` (PLD) portion. So using a parallelism of 3 would fail.

Fixed up issue with UrlDBFunction parallelism not being set properly. We currently have a "crawlDBParallelism" parameter in the CLI options, but it's unused and needs to be removed.

Lots of minor JavaDoc corrections, plus some logging improvements too.