### PR TITLE
Switched the goal for the build-helper-maven-plugin to add-test-sourc…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -707,7 +707,7 @@
                         <id>add-test-source</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <goal>add-source</goal>
+                            <goal>add-test-source</goal>
                         </goals>
                         <configuration>
                             <sources>


### PR DESCRIPTION
…e so that the generated classes for the integration tests end up in the test-classes sub-folder (which is where the failsafe plugin looks for classes). #136