### PR TITLE
Update use of accumulators in parsing code

### DIFF
--- a/src/main/java/com/scaleunlimited/flinkcrawler/focused/BasePageScorer.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/focused/BasePageScorer.java
@@ -2,18 +2,18 @@ package com.scaleunlimited.flinkcrawler.focused;
 
 import java.io.Serializable;
 
-import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
+import org.apache.flink.api.common.functions.RuntimeContext;
+
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
 
 @SuppressWarnings("serial")
 public abstract class BasePageScorer implements Serializable {
 
-    public BasePageScorer() {
+    public void open(RuntimeContext context) throws Exception {
     }
 
-    public abstract void open(CrawlerAccumulator crawlerAccumulator) throws Exception;
-
-    public abstract void close() throws Exception;
+    public void close() throws Exception {
+    }
 
     public abstract float score(ParserResult parse);
 

--- a/src/main/java/com/scaleunlimited/flinkcrawler/focused/FocusedPageParser.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/focused/FocusedPageParser.java
@@ -1,6 +1,7 @@
 package com.scaleunlimited.flinkcrawler.focused;
 
-import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
+import org.apache.flink.api.common.functions.RuntimeContext;
+
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
 import com.scaleunlimited.flinkcrawler.parser.SimplePageParser;
 import com.scaleunlimited.flinkcrawler.pojos.ExtractedUrl;
@@ -18,9 +19,10 @@ public class FocusedPageParser extends SimplePageParser {
     }
 
     @Override
-    public void open(CrawlerAccumulator crawlerAccumulator) throws Exception {
-        super.open(crawlerAccumulator);
-        _pageScorer.open(crawlerAccumulator);
+    public void open(RuntimeContext context) throws Exception {
+        super.open(context);
+        
+        _pageScorer.open(context);
     }
 
     @Override

--- a/src/main/java/com/scaleunlimited/flinkcrawler/functions/ParseFunction.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/functions/ParseFunction.java
@@ -3,14 +3,12 @@ package com.scaleunlimited.flinkcrawler.functions;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.parser.BasePageParser;
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
 import com.scaleunlimited.flinkcrawler.pojos.CrawlStateUrl;
@@ -39,10 +37,17 @@ public class ParseFunction extends BaseProcessFunction<FetchResultUrl, ParsedUrl
     @Override
     public void open(Configuration parameters) throws Exception {
         super.open(parameters);
-        RuntimeContext context = getRuntimeContext();
-        _parser.open(new CrawlerAccumulator(context));
+        
+        _parser.open(getRuntimeContext());
     }
 
+    @Override
+    public void close() throws Exception {
+        _parser.close();
+        
+        super.close();
+    }
+    
     @Override
     public void processElement( FetchResultUrl fetchResultUrl,
                                 Context context,

--- a/src/main/java/com/scaleunlimited/flinkcrawler/functions/ParseSiteMapFunction.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/functions/ParseSiteMapFunction.java
@@ -1,5 +1,6 @@
 package com.scaleunlimited.flinkcrawler.functions;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,8 +12,7 @@ import com.scaleunlimited.flinkcrawler.pojos.FetchResultUrl;
 import com.scaleunlimited.flinkcrawler.pojos.FetchStatus;
 
 @SuppressWarnings("serial")
-public class ParseSiteMapFunction
-        extends BaseFlatMapFunction<FetchResultUrl, ExtractedUrl> {
+public class ParseSiteMapFunction extends BaseFlatMapFunction<FetchResultUrl, ExtractedUrl> {
 
     static final Logger LOGGER = LoggerFactory.getLogger(ParseSiteMapFunction.class);
 
@@ -22,6 +22,13 @@ public class ParseSiteMapFunction
         _siteMapParser = siteMapParser;
     }
 
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        
+        _siteMapParser.open(getRuntimeContext());
+    }
+    
     @Override
     public void flatMap(FetchResultUrl fetchedUrl,
             Collector<ExtractedUrl> collector) throws Exception {

--- a/src/main/java/com/scaleunlimited/flinkcrawler/metrics/CrawlerMetrics.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/metrics/CrawlerMetrics.java
@@ -2,10 +2,13 @@ package com.scaleunlimited.flinkcrawler.metrics;
 
 public enum CrawlerMetrics {
 
-    GAUGE_URLS_CURRENTLY_BEING_FETCHED("URLsCurrentlyBeingFetched"), GAUGE_URLS_FETCHED_PER_SECOND(
-            "URLsFetchedPerSeconds"), GAUGE_URLS_IN_FETCH_QUEUE(
-                    "URLsInFetchQueue"), GAUGE_URLS_IN_FLIGHT(
-                            "URLsInFlight"), GAUGE_UNIQUE_PLDS("UniquePLDs");
+    GAUGE_URLS_CURRENTLY_BEING_FETCHED("URLsCurrentlyBeingFetched"), 
+    GAUGE_URLS_FETCHED_PER_SECOND("URLsFetchedPerSeconds"),
+    GAUGE_URLS_IN_FETCH_QUEUE("URLsInFetchQueue"),
+    GAUGE_URLS_IN_FLIGHT("URLsInFlight"),
+    GAUGE_UNIQUE_PLDS("UniquePLDs"),
+    COUNTER_PAGES_PARSED("PagesParsed"),
+    COUNTER_PAGES_NOTPARSED("PagesFailedParse");
 
     private String _name;
 

--- a/src/main/java/com/scaleunlimited/flinkcrawler/parser/BasePageParser.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/parser/BasePageParser.java
@@ -5,6 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.tika.utils.CharsetUtils;
 
 import com.scaleunlimited.flinkcrawler.config.ParserPolicy;
@@ -18,7 +19,7 @@ import crawlercommons.util.Headers;
 public abstract class BasePageParser implements Serializable {
 
     private ParserPolicy _policy;
-    private transient CrawlerAccumulator _crawlerAccumulator;
+    private transient CrawlerAccumulator _accumulator;
 
     public BasePageParser(ParserPolicy policy) {
         _policy = policy;
@@ -28,18 +29,18 @@ public abstract class BasePageParser implements Serializable {
         return _policy;
     }
 
-    public abstract void open(CrawlerAccumulator crawlerAccumulator) throws Exception;
+    public void open(RuntimeContext context) throws Exception {
+        _accumulator = new CrawlerAccumulator(context);
+    }
 
-    public abstract void close() throws Exception;
+    public void close() throws Exception {
+        
+    }
 
     public abstract ParserResult parse(FetchResultUrl fetchedUrl) throws Exception;
 
-    public void setAccumulator(CrawlerAccumulator crawlerAccumulator) {
-        _crawlerAccumulator = crawlerAccumulator;
-    }
-
-    public CrawlerAccumulator getAccumulator() {
-        return _crawlerAccumulator;
+    protected CrawlerAccumulator getAccumulator() {
+        return _accumulator;
     }
 
     /**

--- a/src/main/java/com/scaleunlimited/flinkcrawler/parser/SimplePageParser.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/parser/SimplePageParser.java
@@ -8,6 +8,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.ParseContext;
@@ -18,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.scaleunlimited.flinkcrawler.config.ParserPolicy;
-import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
+import com.scaleunlimited.flinkcrawler.metrics.CrawlerMetrics;
 import com.scaleunlimited.flinkcrawler.pojos.FetchResultUrl;
 import com.scaleunlimited.flinkcrawler.utils.IoUtils;
 
@@ -124,23 +125,12 @@ public class SimplePageParser extends BasePageParser {
     }
 
     @Override
-    public void open(CrawlerAccumulator crawlerAccumulator) throws Exception {
-        setAccumulator(crawlerAccumulator);
-    }
-
-    @Override
-    public void close() throws Exception {
-    }
-
-    protected synchronized void init() {
-        if (_parser == null) {
-            _parser = new AutoDetectParser();
-        }
-
-        _contentExtractor.reset();
+    public void open(RuntimeContext context) throws Exception {
+        super.open(context);
+        
+        _parser = new AutoDetectParser();
         _linkExtractor.setLinkTags(getParserPolicy().getLinkTags());
         _linkExtractor.setLinkAttributeTypes(getParserPolicy().getLinkAttributeTypes());
-        _linkExtractor.reset();
     }
 
     public void setExtractLanguage(boolean extractLanguage) {
@@ -153,8 +143,6 @@ public class SimplePageParser extends BasePageParser {
 
     @Override
     public ParserResult parse(FetchResultUrl fetchedUrl) throws Exception {
-        init();
-
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("Parsing '{}'", fetchedUrl.getFetchedUrl());
         }
@@ -173,26 +161,27 @@ public class SimplePageParser extends BasePageParser {
             URL baseUrl = getContentLocation(fetchedUrl);
             metadata.add(Metadata.CONTENT_LOCATION, baseUrl.toExternalForm());
 
+            _contentExtractor.reset();
+            _linkExtractor.reset();
+
             Callable<ParserResult> c = new TikaCallable(_parser, _contentExtractor, _linkExtractor,
                     is, metadata, isExtractLanguage(), _parseContext);
             FutureTask<ParserResult> task = new FutureTask<ParserResult>(c);
             Thread t = new Thread(task);
             t.start();
 
-            ParserResult result;
             try {
-                result = task.get(getParserPolicy().getMaxParseDuration(), TimeUnit.MILLISECONDS);
+                ParserResult result = task.get(getParserPolicy().getMaxParseDuration(), TimeUnit.MILLISECONDS);
+                getAccumulator().increment(CrawlerMetrics.COUNTER_PAGES_PARSED);
+                return result;
             } catch (TimeoutException e) {
                 task.cancel(true);
                 t.interrupt();
                 throw e;
-            } finally {
-                t = null;
             }
-
-            // result.setHostAddress(fetchedUrl.getHostAddress());
-            // result.setPayload(fetchedUrl.getPayload());
-            return result;
+        } catch (Exception e) {
+            getAccumulator().increment(CrawlerMetrics.COUNTER_PAGES_NOTPARSED);
+            throw e;
         } finally {
             IoUtils.safeClose(is);
         }

--- a/src/main/java/com/scaleunlimited/flinkcrawler/parser/SimpleSiteMapParser.java
+++ b/src/main/java/com/scaleunlimited/flinkcrawler/parser/SimpleSiteMapParser.java
@@ -4,11 +4,11 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.scaleunlimited.flinkcrawler.config.ParserPolicy;
-import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.pojos.ExtractedUrl;
 import com.scaleunlimited.flinkcrawler.pojos.FetchResultUrl;
 
@@ -33,25 +33,14 @@ public class SimpleSiteMapParser extends BasePageParser {
     }
 
     @Override
-    public void open(CrawlerAccumulator crawlerAccumulator) throws Exception {
-        setAccumulator(crawlerAccumulator);
-    }
-
-    @Override
-    public void close() throws Exception {
-    }
-
-    private void init() {
-        if (_siteMapParser == null) {
-            _siteMapParser = new SiteMapParser();
-        }
+    public void open(RuntimeContext context) throws Exception {
+        super.open(context);
+        
+        _siteMapParser = new SiteMapParser();
     }
 
     @Override
     public ParserResult parse(FetchResultUrl fetchedUrl) throws Exception {
-
-        init();
-
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("Parsing sitemap '{}'", fetchedUrl.getFetchedUrl());
         }

--- a/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedCrawlTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedCrawlTest.java
@@ -17,7 +17,6 @@ import com.scaleunlimited.flinkcrawler.fetcher.MockUrlLengthenerFetcher;
 import com.scaleunlimited.flinkcrawler.fetcher.SiteMapGraphFetcher;
 import com.scaleunlimited.flinkcrawler.fetcher.WebGraphFetcher;
 import com.scaleunlimited.flinkcrawler.functions.FetchUrlsFunction;
-import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
 import com.scaleunlimited.flinkcrawler.parser.SimpleSiteMapParser;
 import com.scaleunlimited.flinkcrawler.pojos.ParsedUrl;
@@ -140,14 +139,6 @@ public class FocusedCrawlTest {
         public float score(ParserResult parse) {
             String title = parse.getParsedUrl().getTitle();
             return Float.parseFloat(title.substring("Synthetic page - score = ".length()));
-        }
-
-        @Override
-        public void open(CrawlerAccumulator crawlerAccumulator) throws Exception {
-        }
-
-        @Override
-        public void close() throws Exception {
         }
     }
 

--- a/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedPageParserTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/focused/FocusedPageParserTest.java
@@ -1,20 +1,16 @@
 package com.scaleunlimited.flinkcrawler.focused;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 
 import java.nio.charset.StandardCharsets;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.scaleunlimited.flinkcrawler.metrics.CrawlerAccumulator;
 import com.scaleunlimited.flinkcrawler.parser.ParserResult;
-import com.scaleunlimited.flinkcrawler.pojos.FetchStatus;
 import com.scaleunlimited.flinkcrawler.pojos.FetchResultUrl;
+import com.scaleunlimited.flinkcrawler.pojos.FetchStatus;
 import com.scaleunlimited.flinkcrawler.pojos.ValidUrl;
 
 import crawlercommons.util.Headers;
@@ -26,12 +22,9 @@ public class FocusedPageParserTest {
         TestPageScorer pageScorer = new TestPageScorer();
         FocusedPageParser parser = new FocusedPageParser(pageScorer);
 
-        CrawlerAccumulator mockCrawlerAccumulator = Mockito.mock(CrawlerAccumulator.class);
-        doNothing().when(mockCrawlerAccumulator).increment(any(Enum.class));
-        doNothing().when(mockCrawlerAccumulator).increment(any(Enum.class), anyLong());
-        doNothing().when(mockCrawlerAccumulator).increment(anyString(), anyString(), anyLong());
-
-        parser.open(mockCrawlerAccumulator);
+        RuntimeContext mockContext = Mockito.mock(RuntimeContext.class);
+        parser.open(mockContext);
+        
         ValidUrl url = new ValidUrl("http://domain.com/page.html");
         Headers headers = new Headers();
         byte[] content = "<html><head><title></title></head><body><p>0.75</p></body></html>"
@@ -48,14 +41,6 @@ public class FocusedPageParserTest {
         @Override
         public float score(ParserResult parse) {
             return Float.parseFloat(parse.getParsedUrl().getParsedText());
-        }
-
-        @Override
-        public void open(CrawlerAccumulator crawlerAccumulator) throws Exception {
-        }
-
-        @Override
-        public void close() throws Exception {
         }
     }
 

--- a/src/test/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopologyTest.java
+++ b/src/test/java/com/scaleunlimited/flinkcrawler/topology/CrawlTopologyTest.java
@@ -52,7 +52,7 @@ public class CrawlTopologyTest {
 
         // Set up for checkpointing with in-memory state.
         env.setStateBackend(new MemoryStateBackend());
-        env.enableCheckpointing(100L, CheckpointingMode.AT_LEAST_ONCE, true);
+        env.enableCheckpointing(1000L, CheckpointingMode.AT_LEAST_ONCE, true);
 
         SimpleUrlNormalizer normalizer = new SimpleUrlNormalizer();
         SimpleWebGraph graph = new SimpleWebGraph(normalizer)


### PR DESCRIPTION
- Make sure parser's `open()` is called from `ParseSiteMapFunction`.
- Push creation of CrawlerAccumulator into BasePageParser.
- Call parser `close()` from ParseXXXFunction's `close()` method.
- Add enum values for good/bad page parse results, and increment those in `SimplePageParser`